### PR TITLE
Add svg favicon and meta tags

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#3498db"/>
+  <text x="8" y="12" font-size="12" text-anchor="middle" fill="white">A</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="favicon.svg">
+    <meta name="description" content="Portfolio of Alp Ozdarendeli's computer vision projects.">
+    <meta name="keywords" content="Alp Ozdarendeli, portfolio, computer vision, graphics, image processing, CS projects">
     <title>My Portfolio</title>
     <style>
         body {

--- a/project1.html
+++ b/project1.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="favicon.svg">
+    <meta name="description" content="Portfolio of Alp Ozdarendeli's computer vision projects.">
+    <meta name="keywords" content="Alp Ozdarendeli, portfolio, computer vision, graphics, image processing, CS projects">
     <title>Project 1: Images of the Russian Empire -- Colorizing the Prokudin-Gorskii Photo Collection</title>
     <style>
         body {

--- a/project2.html
+++ b/project2.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="favicon.svg">
+    <meta name="description" content="Portfolio of Alp Ozdarendeli's computer vision projects.">
+    <meta name="keywords" content="Alp Ozdarendeli, portfolio, computer vision, graphics, image processing, CS projects">
     <title>Project 2: Fun with Filters and Frequencies!</title>
     <style>
         body {

--- a/project3.html
+++ b/project3.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="favicon.svg">
+    <meta name="description" content="Portfolio of Alp Ozdarendeli's computer vision projects.">
+    <meta name="keywords" content="Alp Ozdarendeli, portfolio, computer vision, graphics, image processing, CS projects">
     <title>Project 3: Face Morphing</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"></script>
     <script type="text/x-mathjax-config">

--- a/project4.html
+++ b/project4.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="favicon.svg">
+    <meta name="description" content="Portfolio of Alp Ozdarendeli's computer vision projects.">
+    <meta name="keywords" content="Alp Ozdarendeli, portfolio, computer vision, graphics, image processing, CS projects">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"></script>
     <script type="text/x-mathjax-config">
         MathJax.Hub.Config({

--- a/project5.html
+++ b/project5.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="favicon.svg">
+    <meta name="description" content="Portfolio of Alp Ozdarendeli's computer vision projects.">
+    <meta name="keywords" content="Alp Ozdarendeli, portfolio, computer vision, graphics, image processing, CS projects">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"></script>
     <script type="text/x-mathjax-config">
         MathJax.Hub.Config({

--- a/project6.html
+++ b/project6.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="favicon.svg">
+    <meta name="description" content="Portfolio of Alp Ozdarendeli's computer vision projects.">
+    <meta name="keywords" content="Alp Ozdarendeli, portfolio, computer vision, graphics, image processing, CS projects">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"></script>
     <script type="text/x-mathjax-config">
         MathJax.Hub.Config({


### PR DESCRIPTION
## Summary
- replace binary favicon with small text-based `favicon.svg`
- update HTML pages to reference new icon
- keep SEO meta tags for description and keywords

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e3428cca88329b8341bb84a1e0dde