### PR TITLE
Standardize grid classes and add responsive layout

### DIFF
--- a/project1.html
+++ b/project1.html
@@ -28,7 +28,7 @@
     </div>
 
     <h2>Images</h2>
-    <div class="image-grid">
+    <div class="grid-3">
         <div class="image-container">
             <img src="images/cathedral_output.jpg" alt="cathedral gshift: [5, 2] rshift: [12, 3]">
             <p class="image-description"><i>cathedral.jpg</i> gshift: [5, 2] rshift: [12, 3]</p>

--- a/project2.html
+++ b/project2.html
@@ -19,7 +19,7 @@
         <h2>Part 1: Fun with Filter</h2>
             <h2>Part 1.1: Finite Difference Operator</h2>
             <p>In order to calculate partial derivatives, I used finite difference kernels. Dx kernel is created by np.array([[1, -1]]) and Dy kernel is created by np.array([[1], [-1]]. By convolving the image with these finite difference kernels, I have obtained the partial derivatives in horizontal and vertical directions. The gradient magnitude is calculated by taking the square root of the sum of squared partial derivatives in the x and y directions. This is essentially calculating the L2 norm of the gradient vector at each pixel. In order to binarize the gradient magnitude, I have chosen a threshold of 0.29 per pixel.</p>
-            <div class="image-grid">
+            <div class="grid-3">
             <div class="image-container">
                 <img src="proj2images/d_x.jpg" alt="d_x">
                 <p class="image-subtitle">d_x</p>
@@ -41,7 +41,7 @@
         <h2>Part 1.2: Derivative of Gaussian (DoG) Filter</h2>
         <p> I have blurred the original image by doing convolution with a 2D Gaussian kernel, with sigma = 1 and kernel size 6. 2D Gaussian kernel is created by firstly creating a 1D Gaussian filter with cv2.getGaussianKernel() and doing outer product with its transpose. Then, I applied the same procedure from part 1.1 to get the partial derivatives and gradient magnitude of the blurred image.</p>
         <p>The results with Gaussian filter are noticably smoother, having thicker edges even though the I used a significantly lower threshold, 0.066. Noise in the background of the image is less apparent with the Gaussian filter, and gradient magnitude is significantly lower.</p>
-        <div class="image-grid">
+        <div class="grid-3">
             <div class="image-container">
                 <img src="proj2images/im_blurred.jpg" alt="Image with Gaussian Filter">
                 <p class="image-subtitle">Image with Gaussian Filter</p>
@@ -66,7 +66,7 @@
         <div class="clear-float"></div>
         <p> This time, I convolved with the derivative of Gaussian instead of convolving the image twice with partial derivatives and the Gaussian filter.</p>
         <p> The results are visibly the same because of convolution operation's associativity property. I used the same threshold for the binary gradient magnitude and obtained the same edge image. </p>
-                <div class="image-grid">
+                <div class="grid-3">
             <div class="image-container">
                 <img src="proj2images/dog_dx.jpg" alt="Dx of DoG">
                 <p class="image-subtitle">Dx of DoG</p>
@@ -89,7 +89,7 @@
             <h2>Part 2.1: Image "Sharpening</h2>
             <p>For this part, my goal is to sharpen images. In order to sharpen an image, I apply Gaussian filter to get the low frequencies of the image. When the low frequencies are substracted from the original image, I get the high frequencies of the image. By adding the high frequencies to the original image, original image can be sharpened. I combines these operations into a single convolution operation which can be formulized convolving each channel of the image with (1 + alpha) * unit_impulse - alpha * gauss_kernel where alpha is the coefficient of the sharpening. </p>
         <div class="clear-float"></div>
-        <div class="image-gri">
+        <div class="grid-2">
         <div class="image-container">
             <img src="proj2images/taj.jpg" alt="Taj Mahal">
             <p class="image-subtitle">Taj Mahal</p>
@@ -100,7 +100,7 @@
         </div>
         </div>
         <div class="clear-float"></div>
-        <div class="image-gri">
+        <div class="grid-2">
         <div class="image-container">
             <img src="proj2images/ataturk.jpg" alt="Mustafa Kemal Ataturk">
             <p class="image-subtitle">Mustafa Kemal Ataturk</p>
@@ -122,7 +122,7 @@
         </div>
         <div class="clear-float"></div>
         <p>For evaluation, I attempted to sharpen an image after blurring it. I observed that sharpening process was not able to sharpen the blurred image to its original quality, regardless of the value of the coefficient alpha. When an image is blurred, it becomes more noisy than the original and lose some of its details that even sharpening cannot recover. </p>
-        <div class="image-gri">
+        <div class="grid-2">
         <div class="image-container">
             <img src="proj2images/tt_arena.jpg" alt="Rams park">
             <p class="image-subtitle">Rams park</p>
@@ -139,7 +139,7 @@
         <div class="clear-float"></div>
         <h2>Part 2.2: Hybrid Images</h2>
             <p>For this part, my goal is to create hybrid images that can be interpreted differently from different distances. In order to do this, I capture low frequency and high frequency of different images by passing the images through a Gaussian filter. High frequencies are captured by subtracting the image passed through the filter from its original image. The hybrid image is the average of both filtered images. I used color to enhance the effect of combining the images.</p>
-        <div class="image-grid">
+        <div class="grid-3">
         <div class="image-container">
             <img src="proj2images/DerekPicture.jpg" alt="Derek">
             <p class="image-subtitle">Derek</p>
@@ -154,7 +154,7 @@
         </div>
         </div>
         <div class="clear-float"></div>
-            <div class="image-grid">
+            <div class="grid-3">
         <div class="image-container">
             <img src="proj2images/darwin.jpg" alt="Darwin">
             <p class="image-subtitle">Darwin</p>
@@ -169,7 +169,7 @@
         </div>
         </div>
         <div class="clear-float"></div>
-        <div class="image-grid">
+        <div class="grid-3">
         <div class="image-container">
             <img src="proj2images/tann.jpg" alt="Tan">
             <p class="image-subtitle">Tan</p>
@@ -186,7 +186,7 @@
         <div class="clear-float"></div>
     </div>
     <p>Two-Tan was my favorite result so far. Here is its frequency analysis with Fourier transformation:</p>
-    <div class="image-grid">
+    <div class="grid-3">
         <div class="image-container">
             <img src="proj2images/grayscale_tan.jpg" alt="Tan FFT">
             <p class="image-subtitle">Tan FFT</p>
@@ -210,7 +210,7 @@
         </div>
         <div class="clear-float"></div>
     <p>For a failed one, I tried to make a hybrid of Gheorghe Hagi and Didier Drogba. Unfortunately, it wasn't very successful but I will use them again for another technique. </p>
-    <div class="image-grid">
+    <div class="grid-3">
         <div class="image-container">
             <img src="proj2images/hagi.jpg" alt="Gheorghe Hagi">
             <p class="image-subtitle">Gheorghe Hagi</p>
@@ -228,7 +228,7 @@
     <h2>Part 2.3: Gaussian and Laplacian Stacks</h2>
             <p>For this part, my goal is to blend images. In order to blend, I created Gaussian stacks and Laplacian stacks for the images. The Laplacian stacks are formed by substracting the consecutive images in their Gaussian stacks. The last level of the Laplacian stack is the last level of the Gaussian stack so the Laplacian and Gaussian stacks have the same number of levels.</p>
         <h2>Apple Gauss Stack</h2>
-<div class="image-g">
+<div class="grid-3">
     <div class="image-container">
         <img src="proj2images/gauss_app0.jpg" alt="Apple Gauss Level 0">
         <p class="image-subtitle">Level 0</p>
@@ -256,7 +256,7 @@
 </div>
 
 <h2>Apple Laplace Stack</h2>
-<div class="image-g">
+<div class="grid-3">
     <div class="image-container">
         <img src="proj2images/lap_app0.jpg" alt="Apple Laplace Level 0">
         <p class="image-subtitle">Level 0</p>
@@ -284,7 +284,7 @@
 </div>
 
 <h2>Orange Gauss Stack</h2>
-<div class="image-g">
+<div class="grid-3">
     <div class="image-container">
         <img src="proj2images/gauss_or0.jpg" alt="Orange Gauss Level 0">
         <p class="image-subtitle">Level 0</p>
@@ -312,7 +312,7 @@
 </div>
 
 <h2>Orange Laplace Stack</h2>
-<div class="image-g">
+<div class="grid-3">
     <div class="image-container">
         <img src="proj2images/lap_or0.jpg" alt="Orange Laplace Level 0">
         <p class="image-subtitle">Level 0</p>
@@ -340,7 +340,7 @@
 </div>
     <div class="clear-float"></div>
     <h2>Oraple</h2>
-        <div class="image-gri">
+        <div class="grid-2">
         <div class="image-container">
             <img src="proj2images/oraple.jpg" alt="Oraple!">
             <p class="image-subtitle">Oraple!</p>
@@ -355,7 +355,7 @@
     <p>In order to blend, I used Laplacian stacks of the images and the Gaussian stack for the mask. We apply Gaussian filter to the mask at each layer so that blending is smoother. After creating the Laplacian stack for the images and Gaussian stack for the mask, I create a blend stack for the images by merging them using the formula blend[i] = mask_gauss[i] * apple_laplace[i] + (1 - mask_gauss[i]) * orange_laplace[i] In this process, the Gaussian mask is applied to one image, while its inverse (1 - mask) is applied to the other for each level in the Laplacian pyramid. After creating a stack of blended images at each level, I collapse them to produce the final blended image. This enables a smooth transition between the images.</p>
     <h2>Hagi & Drogba</h2>
     <p> Finally, I was able to blend Didier Drogba and Gheorghe Hagi onto the same image.</p>
-    <div class="image-gri">
+    <div class="grid-2">
         <div class="image-container">
             <img src="proj2images/hagi.jpg" alt="Gheorghe Hagi">
             <p class="image-subtitle">Gheorghe Hagi</p>
@@ -375,14 +375,14 @@
         </div>
         <div class="clear-float"></div>
     <p> Here is its blending process.</p>
-     <div class="image-gr">
+     <div class="grid-1">
         <div class="image-container">
             <img src="proj2images/drogba_hagi_blend.jpg" alt="Drogba & Hagi Blend Process">
             <p class="image-subtitle">Drogba & Hagi Blend Process</p>
         </div>
         </div>
     <h2>Spidermeme Recreation</h2>
-    <div class="image-gri">
+    <div class="grid-2">
         <div class="image-container">
             <img src="proj2images/spiderman.jpg" alt="Spiderman">
             <p class="image-subtitle">Spiderman</p>
@@ -403,7 +403,7 @@
         <div class="clear-float"></div>
     <h2>Early Halloween</h2>
     <p>I think I could have achieved a better blending with a better mask but still it is early Halloween!</p>
-    <div class="image-gri">
+    <div class="grid-2">
         <div class="image-container">
             <img src="proj2images/jokerr_750.jpg" alt="Joker">
             <p class="image-subtitle">Joker</p>

--- a/project3.html
+++ b/project3.html
@@ -24,7 +24,7 @@
     <div class="project-overview">
         <h2>Part 1:  Defining Correspondences</h2>
             <p> To morph two images, we need to select points of correspondences. I used the given tool to select points on the images. After defining the correspondences, I used Delaney Triangulation to triangulate the mean points of Larry David's and Can Ruso's images to find the mean shape. </p>
-            <div class="image-grid">
+            <div class="grid-3">
             <div class="image-container">
                 <img src="proj3images/ruso_tr.png" alt="Ruso points">
                 <p class="image-subtitle">Ruso points</p>
@@ -99,7 +99,7 @@
     <p> Thus, we can use a linear algebra solver to find a, b, c, d, e, and f, and calculate the transformation matrix.</p>
     <p> Once we have the tranformation matrix for every triangle, we use inverse warping to warp original images to the average shape. Since I use inverse warping, the corresponding pixels in the source image can be between pixels so I used RegularGridInterpolator to interpolate the pixel values for dissolving. Applying warping to both of the images, and taking the point-wise average of them gives us the average face. This is basically morphing with warp and morph fraction of 0.5. </p>
 </html>
-        <div class="image-grid">
+        <div class="grid-3">
         <div class="image-container">
             <img src="proj3images/warpedcan.png" alt="Warped Can">
             <p class="image-subtitle">Warped Can</p>
@@ -117,7 +117,7 @@
         <h2>Part 3: The Morph Sequence</h2>
             <p> To produce the morphing sequence, I applied the previous procedure for finding the mid-way face with different warp and dissolve fractions. To create 45 frames, I increase the fractions by 1/45 for each frame. Dissolve fraction determines the weight of source image for the final image while taking the average of the source images. Warp fraction determines how close the shape of final image will be to the source image. Here is a gif with 45 frames for transforming Larry David to Can:</p>
         <div class="clear-float"></div>
-        <div class="image-gr">
+        <div class="grid-1">
         <div class="image-container">
             <img src="proj3images/larrycan.gif" alt="Larry David to Can Ruso">
             <p class="image-subtitle">Larry David to Can Ruso</p>
@@ -125,7 +125,7 @@
         </div>
         <div class="clear-float"></div>
         <p> I also applied the morphing sequence to my father and myself. It turns out we look pretty alike:</p>
-        <div class="image-gr">
+        <div class="grid-1">
         <div class="image-container">
             <img src="proj3images/morph.gif" alt="My father to Me">
             <p class="image-subtitle">My father to Me</p>
@@ -134,7 +134,7 @@
         <h2>Part 4: The "Mean face" of a population</h2>
             <p> For this part, I used all of the data points from Danes dataset to compute the mean face of the population. Firstly, I found the average of all the corresponding points for the given images. I warped all images to the average shape and computed their average to get the mean face. Here are a few examples of the warped images to the average shape:</p>
         <div class="clear-float"></div>
-        <div class="image-gri">
+        <div class="grid-2">
         <div class="image-container">
             <img src="proj3images/morphed2.png" alt="Illustration of morphed2">
         </div>
@@ -150,14 +150,14 @@
         </div>
         <div class="clear-float"></div>
         <p> Here is the mean face of the population:</p>
-        <div class="image-gr">
+        <div class="grid-1">
         <div class="image-container">
             <img src="proj3images/avgface.jpg" alt="Illustration of avgface">
         </div>
         </div>
         <div class="clear-float"></div>
         <p> After computing the mean face of the population, I warped Can's face into the average face, and warped the mean face into Can's face:</p>
-        <div class="image-gri">
+        <div class="grid-2">
         <div class="image-container">
             <img src="proj3images/warped_avg.png" alt="Illustration of warped avg">
         </div>
@@ -169,7 +169,7 @@
         <h2>Part 5: Caricatures: Extrapolating from the mean</h2>
             <p> I also caricaturize Can's image. Instead of warping Can's image to the mean shape, we can warp Can's face to can_shape + alpha(can_shape - average_shape) for a negative alpha and a positive alpha > 1 to extrapolate Can's face. These basically exaggerates Can's facial features that are far away from the mean face and the mean face's features that are far away from Can's face. Here are the results:</p>
         <div class="clear-float"></div>
-        <div class="image-gri">
+        <div class="grid-2">
         <div class="image-container">
             <img src="proj3images/alpha1_7.png" alt="Illustration of alpha1 7">
         </div>
@@ -182,7 +182,7 @@
         <p> I completed two Bells and Whistles. For the first one, I made a video of myself at different ages. There are 13 different pictures of myself that are morphed sequentially to produce aging effect. I used the morphing sequence defined earlier for each consecutive image. Here is the link:</p>
         <a href="https://youtu.be/4YwmFifFEhw"> Link to my video</a>
         <p>For the second B&W, I computed the mean face of all the woman images in Danes dataset, and tried to morph only Can's appearance, only Can's shape and both. These are done by having 0 warp frac and 1 dissolve frac, 1 warp frac and 0 dissolve frac, and 0.5 dissolve and warp frac.</p>
-        <div class="image-gri">
+        <div class="grid-2">
         <div class="image-container">
             <img src="proj3images/womanavg.jpg" alt="Mean Woman Face">
             <p class="image-subtitle">Mean Woman Face</p>

--- a/project4.html
+++ b/project4.html
@@ -22,7 +22,7 @@
     <div class="project-overview">
         <h2>Shoot the Pictures</h2>
             <p> Here are the pictures I used for this project: </p>
-            <div class="image-gri">
+            <div class="grid-2">
             <div class="image-container">
                 <img src="proj4images/IMG_5854.png" alt="Illustration of IMG 5854">
             </div>
@@ -103,7 +103,7 @@
             <p> After calculating the homography, I use inverse warping to warp original images to the desired shape. Since I use inverse warping, the corresponding pixels in the source image can be lie between pixels so I used RegularGridInterpolator to interpolate the pixel values.</p>
         <p> For image rectification I used the inverse warping with homography I calculated earlier. Instead of selecting corresponding points between two images, I chose the edges of a rectangle or a square shape from an image and I manually defined the corresponding points so that these edges would form a rectified rectangular shape. Here are the corresponding points I have chosen and the resultant rectified images:</p>
         <div class="clear-float"></div>
-        <div class="image-gri">
+        <div class="grid-2">
         <div class="image-container">
             <img src="proj4images/yastikp.png" alt="Illustration of yastikp">
         </div>
@@ -121,7 +121,7 @@
         <p>For the first image, I have manually chosen the corresponding points to be [[200,200],[500,200],[500,500],[200,500]] to form a square. For the second iamge, I have manually chosen the corresponding points to be [[200,200],[800,200],[800,400],[200,400]] to form a rectangle.</p>
         <h2>Blend the images into a mosaic</h2>
             <p> To blend the images into a mosaic, firstly, I warped one of the images based on the correspondence points. Before warping, I calculate the final image's shape and align the warped image with the original image by calculating if there is any offsets. Then, I created indicator masks for both the original and warped image in the final image's shape. These masks set pixels to 1 if there is a corresponding pixel in the original or warped image. I found the overlapping pixels between the two images using these masks. After finding the overlapping pixels, I used a Laplacian stack for blending. For a Laplacian stack, we need a mask for the images to blend. I separated the mask into two parts. The first part is the non-overlapping pixels for the original image. Since there is no overlap between the images at these pixels, I used the indicator mask I created for the images at these pixels. For the overlapping pixels, the computation is more complicated. I used cv2.distanceTransform to calculate distance to non-overlapping pixels from both images for each overlapping pixel. Then, I found the ratio of distance2/(distance2+distance1) for each overlapping pixel where distance1 indicates the distance to the closest non-overlapping pixel in the original image. By combining these two parts, I create the mask for the Laplacian stack: </p>
-        <div class="image-grid">
+        <div class="grid-3">
         <div class="image-container">
             <img src="proj4images/mask_1_non_overlap.png" alt="Non-overlap part of the mask">
             <p class="image-subtitle"> Non-overlap part of the mask</p>
@@ -136,7 +136,7 @@
         </div>
         </div>
         <p> After creating the mask, I used a Laplacian stack with original and warped images padded to the final image's shape to create the mosaic:
-        <div class="image-gri">
+        <div class="grid-2">
         <div class="image-container">
             <img src="proj4images/IMG_5854.png" alt="Illustration of IMG 5854">
         </div>
@@ -151,7 +151,7 @@
         </div>
         </div>
         <p> Here are other examples of mosaicing with their original images, mask, and the final blended image:</p>
-        <div class="image-gri">
+        <div class="grid-2">
         <div class="image-container">
             <img src="proj4images/img3-1.png" alt="Illustration of img3-1">
         </div>
@@ -160,7 +160,7 @@
         </div>
         </div>
         <div class="clear-float"></div>
-        <div class="image-grid">
+        <div class="grid-3">
         <div class="image-container">
             <img src="proj4images/mask3-1.png" alt="Illustration of mask3-1">
         </div>
@@ -178,7 +178,7 @@
         </div>
         </div>
         <div class="clear-float"></div>
-        <div class="image-gri">
+        <div class="grid-2">
         <div class="image-container">
             <img src="proj4images/img2-2.png" alt="Illustration of img2-2">
         </div>
@@ -187,7 +187,7 @@
         </div>
         </div>
         <div class="clear-float"></div>
-        <div class="image-grid">
+        <div class="grid-3">
         <div class="image-container">
             <img src="proj4images/mask21.png" alt="Illustration of mask21">
         </div>
@@ -207,7 +207,7 @@
     <h1>Part B</h1>
     <h2>Detecting Corner Features</h2>
     <p>To detect the corner features, I used the given Harris Point detector. For one of my images, here is the points that Harris Point detector classified as likely to be corner features:</p>
-            <div class="image-gr">
+            <div class="grid-1">
         <div class="image-container">
             <img src="proj4images/harris.png" alt="Illustration of harris">
         </div>
@@ -215,7 +215,7 @@
         <div class="clear-float"></div>
     <h2>Adaptive Non-Maximal Suppression</h2>
     <p>Even though Harris Point detector detects corner-like features, clearly, there are too much points and they are abundant. Thus, I use Adaptive Non-Maximal Suppression to extract features. To get correspondence points that are far away from each other and have strong corner features, we sort the distance based on the strength of their corner response. For each point, we calculate the distance to the closest point who has a stronger corner response. Then, we sort the points based on these distances and limit the number of features to be extracted to 300. Here is the result: </p>
-                <div class="image-gr">
+                <div class="grid-1">
         <div class="image-container">
             <img src="proj4images/limitedharris.png" alt="Illustration of limitedharris">
         </div>
@@ -223,7 +223,7 @@
         <div class="clear-float"></div>
     <h2>Extracting Feature Descriptors</h2>
     <p> After identifying the features, now we have to extract feature descriptors. For each feature, we extract 40x40 windows, and downsample to get 8x8 patches. Before this step, low-pass Gaussian filter is applied. After getting the patches, each patch is normalized and reshaped to form 64 element feature descriptors for each feature. Here are some examples:</p>
-    <div class="image-gri">
+    <div class="grid-2">
         <div class="image-container">
             <img src="proj4images/patch1.png" alt="Illustration of patch1">
         </div>
@@ -234,7 +234,7 @@
         <div class="clear-float"></div>
     <h2>Matching Feature Descriptors</h2>
     <p>After extracting the feature descriptors for each image, we need to match them. I created k-d trees for each image. I query the closest 2 pairwise feature vectors for each feature in one of the images. I calculated the L2 norm distance ratio of these 2 vectors to the original features. Using Lowe's trick, I only keep the closest feature vectors that have less a certain threshold distance ratio and also checked with the other tree to ensure that original feature vector is also the closest feature vector for the chosen feature. This greatly reduced the outliers, and here is the filtered matches: </p>
-    <div class="image-gri">
+    <div class="grid-2">
         <div class="image-container">
             <img src="proj4images/features1.png" alt="Illustration of features1">
         </div>
@@ -248,7 +248,7 @@
     
     <h2>Produce Mosaics</h2>
         <p>After computing homographies with RANSAC, I ran the same code that I used for part A to produce mosaics for the same 3 pictures. Here are the side-by-side manually and automatically stitched results for these images:</p>
-        <div class="image-gri">
+        <div class="grid-2">
         <div class="image-container">
             <img src="proj4images/img3_ful.png" alt="Manual Stitching">
             <p class="image-subtitle">Manual Stitching</p>
@@ -259,7 +259,7 @@
         </div>
         </div>
         <div class="clear-float"></div>
-        <div class="image-gri">
+        <div class="grid-2">
         <div class="image-container">
             <img src="proj4images/mosaic1.png" alt="Manual Stitching">
             <p class="image-subtitle">Manual Stitching</p>
@@ -270,7 +270,7 @@
         </div>
         </div>
         <div class="clear-float"></div>
-                <div class="image-gri">
+                <div class="grid-2">
         <div class="image-container">
             <img src="proj4images/manual2.png" alt="Manual Stitching">
             <p class="image-subtitle">Manual Stitching</p>

--- a/project5.html
+++ b/project5.html
@@ -22,7 +22,7 @@
     <div class="project-overview">
         <h2>Part 0: Setup</h2>
             <p>  For the setup part, I use DeepFloyd IF as the diffusion model. For Part A, I used the seed 180. Deepfloyd is a two-stage model. In the first stage, 64 x 64 images are produced and second stage takes these images and produces final images of size 256 x 256. To test the setup, I used the given prompts to generate the following outputs: </p>
-        <div class="image-grid">
+        <div class="grid-3">
             <div class="image-container">
                 <img src="images5/parta1_1.png" alt="a man wearing a hat">
                 <p class="image-subtitle"> a man wearing a hat</p>
@@ -38,7 +38,7 @@
         </div>
         <div class="clear-float"></div>
             <p> The generated images actually represent the prompts pretty well. To test the effect of num_inference_steps on the outputs, I test the prompt 'an oil painting of a snowy mountain village' with num_inference_steps 7 and 46 in addition to 20 given above. Here are outputs with num_inference_steps 7 and 46 respectively:</p>
-            <div class="image-gri">
+            <div class="grid-2">
             <div class="image-container">
                 <img src="images5/parta1_2.png" alt="an oil painting of a snowy mountain village (num_inference_steps = 7)">
                 <p class="image-subtitle"> an oil painting of a snowy mountain village (num_inference_steps = 7)</p>
@@ -52,7 +52,7 @@
         <p>With increasing num_inference_steps, the images become more detailed and better reflect the prompts.</p>
         <h2>1.1 Implementing the Forward Process</h2>
         <p>Now, I implement the forward process. For the forward process, given a clean image, I get a noisy image for a timestep t by sampling noise from a Gaussian. In addition to these, I also scale the image. The original Campanile image is shown below at different noise levels. Larger t represents larger noise.</p>
-        <div class="image-grid">
+        <div class="grid-3">
             <div class="image-container">
                 <img src="images5/noise1.png" alt="Noisy Campanile at t=250">
                 <p class="image-subtitle">Noisy Campanile at t=250</p>
@@ -69,7 +69,7 @@
         <div class="clear-float"></div>
         <h2>1.2 Classical Denoising</h2>
 <p>In this section, I use classical denoising to denoise the noisy images produced in the previous part. For classical denoising, I take a noisy image and try to denoise it by Gaussian filtering. Here are the results for different timestamps:</p>
-        <div class="image-grid">
+        <div class="grid-3">
             <div class="image-container">
                 <img src="images5/noise1.png" alt="Noisy Campanile at t=250">
                 <p class="image-subtitle">Noisy Campanile at t=250</p>
@@ -84,7 +84,7 @@
             </div>
         </div>
         <div class="clear-float"></div>
-                        <div class="image-grid">
+                        <div class="grid-3">
             <div class="image-container">
                 <img src="images5/cdns1.png" alt="Classical Denoised Campanile at t=250">
                 <p class="image-subtitle">Classical Denoised Campanile at t=250</p>
@@ -101,7 +101,7 @@
         <div class="clear-float"></div>
     <h2>1.3 One-Step Denoising</h2>
     <p> For one-step denoising, I use a pretrained denoiser stage_1.unet to find the noise in the images. This UNet is already trained on a very large dataset but it was trained text conditioning so I use the embedding of the given prompt "a high quality photo” for conditioning. Then, I remove this image to recover a clean image for noisy images produced in part 1.1:</p>
-                <div class="image-grid">
+                <div class="grid-3">
             <div class="image-container">
                 <img src="images5/noise1.png" alt="Noisy Campanile at t=250">
                 <p class="image-subtitle">Noisy Campanile at t=250</p>
@@ -116,7 +116,7 @@
             </div>
         </div>
         <div class="clear-float"></div>
-                    <div class="image-grid">
+                    <div class="grid-3">
             <div class="image-container">
                 <img src="images5/odn1.png" alt="One-Step Denoised Campanile at t=250">
                 <p class="image-subtitle">One-Step Denoised Campanile at t=250</p>
@@ -133,7 +133,7 @@
         <div class="clear-float"></div>
     <h2> 1. 4 Iterative Denoising</h2>
     <p> In the previous part, performance gets worse with more noisy images. To combat this, I will implement iterative denoising. For iterative denoising, I create a new list of timesteps,strided_timesteps, to skip some steps. The stride of steps will be 30. I add noise to the test image at timestep[10] and run the implemented iterative_denoise function on this image with i_start algorithm being 10. In the following, denoised image is displayed at every fifth step and final clean image prediction is shown in comparison to other techniques:<p>
-                    <div class="image-grid">
+                    <div class="grid-3">
             <div class="image-container">
                 <img src="images5/f1.png" alt="Illustration of f1">
             </div>
@@ -168,7 +168,7 @@
         <div class="clear-float"></div>
         <h2>1.5 Diffusion Model Sampling </h2>
         <p> For this part, I use iterative_denoise function I defined earlier to generate images from scratch by passing 0 as the i_start argument. I also pass in random noise, and the function denoises pure noise. Here are 5 samples with the prompt “a high quality photo”:</p>
-                        <div class="image-griddd">
+                        <div class="grid-3">
             <div class="image-container">
                 <img src="images5/sample1.png" alt="Illustration of sample1">
             </div>
@@ -188,7 +188,7 @@
         <div class="clear-float"></div>
         <h2>1.6 Classifier-Free Guidance (CFG)</h2>
         <p>The quality of the results in the previous section were not great. To significantly improve image quality, I will use CFG in this section. For CFG, I compute both conditional and unconditional noise estimate. In CFG, we have a hyperparameter, named scale in the function, that determines its strength. When scale is 0, CFG is essentially unconditional noise estimate but when scale is bigger than 1, CFG can produce much more quality images. Here are 5 samples from CFG with scale=7 and prompt “a high quality photo”:</p>
-                                        <div class="image-griddd">
+                                        <div class="grid-3">
             <div class="image-container">
                 <img src="images5/cfg1.png" alt="Illustration of cfg1">
             </div>
@@ -208,7 +208,7 @@
         <div class="clear-float"></div>
     <h2> 1.7 Image-to-image Translation </h2>
     <p>In this section, I follow the SDEdit algorithm. I noise the original image a little bit first, then, force it back to the image manifold without conditioning. As a result, I get an image similar to the original image. For this section, I will use the 3 test images, one of them being the Campanile photo. Here are the edits of the test images, at different noise levels 1, 3, 5, 7, 10, 20 with "a high quality photo":</p>
-                <div class="image-g">
+                <div class="grid-3">
             <div class="image-container">
                 <img src="images5/1-1.png" alt="i_start=1">
                                 <p class="image-subtitle">i_start=1</p>
@@ -300,7 +300,7 @@
         <div class="clear-float"></div>
     <h2>1.7.1 Editing Hand-Drawn and Web Images </h2>
     <p> The technique I used in the previous section also performs pretty well for nonrealistic images that is projected it to the natural image manifold. To test for these, I will use 1 image from web and 2 images by my hand drawing:</p>
-                    <div class="image-g">
+                    <div class="grid-3">
             <div class="image-container">
                 <img src="images5/w1-1.png" alt="i_start=1">
                                 <p class="image-subtitle">i_start=1</p>
@@ -392,7 +392,7 @@
         <div class="clear-float"></div>
     <h2> 1.7.2 Inpainting </h2>
     <p>Based on the Repaint paper, I implement inpainting in this section using the same procedure. Given a mask, when I run the diffusion denoising loop, I replace everything except the mask area with the original images but with the added noise based on timestep t. So, new content is only produced in the pixels where mask has value 1. Here are my results for inpainting: </p>
-        <div class="image-gi">
+        <div class="grid-3">
             <div class="image-container">
                 <img src="images5/img1.png" alt="Original">
                                 <p class="image-subtitle">Original</p>
@@ -449,7 +449,7 @@
         <div class="clear-float"></div>
     <h2>1.7.3 Text-Conditional Image-to-image Translation</h2>
     <p>In this section, I will do text conditional image to image translation. It is pretty much the same with SDEdit. Differently from the original SDEdit, I will change the prompt from "a high quality photo" to the prompt of my choosing to guide the projection with text prompt. Here are the results with different noise levels and different prompts:</p>
-                        <div class="image-g">
+                        <div class="grid-3">
             <div class="image-container">
                 <img src="images5/c1-1.png" alt="i_start=1">
                                 <p class="image-subtitle">i_start=1</p>
@@ -541,7 +541,7 @@
         <div class="clear-float"></div>
     <h2> 1.8 Visual Anagrams </h2>
     <p>In this section, I will implement visual diagrams. Visual anagrams are images such that the image looks like a prompt —prompt1— upright, but looks like another prompt —prompt2— when it is turned upside down. I implement visual anagrams by denoising the image at a timestep t with prompt1 and get a noise estimate e_1. Then, I turned the image upside down, denoise the flipped image with prompt2 to get a noise estimate e_2. Finally, I turned e_2 upside down and took its average with e_1 with to get the final noise estimate. The denoising step is done with this final noise estimate. Here are my results, and prompts:</p>
-    <div class="image-gri">
+    <div class="grid-2">
             <div class="image-container">
                 <img src="images5/flip1.png" alt=""an oil painting of people around a campfire"">
                 <p class="image-subtitle">"an oil painting of people around a campfire"</p>
@@ -570,7 +570,7 @@
         <div class="clear-float"></div>
     <h2>1.9 Hybrid Images </h2>
     <p> In this section, I will implement hybrid images implementation. Hybrids images appear as a prompt from afar, and as another prompt from a closer range. To create hybrid images, I will use a similar technique to the previous section. I will first estimate the noise with two different prompts, and will pass them through low-pass filter. Then, I will combine the low frequency component of one noise with the high frequency component of the other noise. Their combination will form the final noise estimate. Here are my results by using Gaussian blur with kernel size 33 and sigma 2:</p>
-    <div class="image-grid">
+    <div class="grid-3">
         <div class="image-container">
             <img src="images5/hybrid1.png" alt="'a lithograph of a skull' and 'a lithograph of waterfalls'">
             <p class="image-subtitle">'a lithograph of a skull' and 'a lithograph of waterfalls'</p>
@@ -588,14 +588,14 @@
     <h1>Part B: Diffusion Models from Scratch</h1>
     <h2>Training a Single-Step Denoising UNet</h2>
     <p>For the second part of the project, I implement diffusion models from scratch. As a first step, I train single-step denoising UNet. This denoiser will optimize for producing a clean image given a noisy image. Firstly, I follow the model diagram for UNet to define its architecture. To train a denoiser with UNet, I use the image dataset from MNIST. Given a clean image, I add a random noise with sigma coefficient to create a noised image. Here are examples of noised images with different sigmas: </p>
-    <div class="image-gr">
+    <div class="grid-1">
         <div class="image-container">
             <img src="images5/ima4.png" alt="Illustration of ima4">
         </div>
         </div>
         <div class="clear-float"></div>
     <p> I train UNet to minimize the loss between denoised image from UNet given the noised image and the original clean image. I shuffle the training dataset before creating its data loader. In this part, I will be using hidden dimension of 128 and learning rate of 1e-4 for Adam optimizer.  Here are the sample results after training for 1 and 5 epochs:</p>
-    <div class="image-gri">
+    <div class="grid-2">
         <div class="image-container">
             <img src="images5/ima1.png" alt="Illustration of ima1">
         </div>
@@ -605,14 +605,14 @@
         </div>
         <div class="clear-float"></div>
     <p> In the training, I train the model for sigma = 0.5. Here is how the model performs for other sigma values that it wasn’t exactly trained for:</p>
-        <div class="image-gr">
+        <div class="grid-1">
         <div class="image-container">
             <img src="images5/ima3.png" alt="Illustration of ima3">
         </div>
         </div>
         <div class="clear-float"></div>
     <p>Here is the training loss curve during the whole training process:</p>
-    <div class="image-gr">
+    <div class="grid-1">
         <div class="image-container">
             <img src="images5/ima5.png" alt="Illustration of ima5">
         </div>
@@ -620,14 +620,14 @@
         <div class="clear-float"></div>
     <h2>Training a Diffusion Model</h2>
     <p>In this part, I will train a UNet model that iteratively denoises an image. For this, I will implement DDPM. For this part, our optimization problem is not the same as the previous part., even though they are mathematically equivalent In this part, I UNet predicts the added noise rather than the clean image itself. In order to get a quality result, we need to iteratively denoise the image. Thus, following the diagram and using FCBlocks, I inject time t into the UNet model architecture for conditioning. To train the model, I pick a random image from the training set data loader, pick a random t, and train the denoiser for computing the noise  of the image at timestep t. In This section, I use hidden dimension of 64, initial learning rate of 1e-3 for Adam optimizer, and gamma of 0.1 ** (1.0/num_epochs) for exponential learning rate decay scheduler. </p>
-                <div class="image-gr">
+                <div class="grid-1">
         <div class="image-container">
             <img src="images5/time3.png" alt="Illustration of time3">
         </div>
         </div>
         <div class="clear-float"></div>
     <p>Also, during training I sample the model for 5 and 20 epochs:</p>
-            <div class="image-gri">
+            <div class="grid-2">
         <div class="image-container">
             <img src="images5/time1.png" alt="Illustration of time1">
         </div>
@@ -638,14 +638,14 @@
         <div class="clear-float"></div>
     <h2>2.4 Adding Class-Conditioning to UNet</h2>
     <p>In order to improve our results from the previous section, I will add class-conditioning to UNet in this section by adding 2 more FCBlocks to the UNet architecture. Class-conditioning vector— one-hot vector c— will be set to 0 %10 of the time by implementing p_uncond = 0. 1. Training hyper parameters are basically the same as the previous section. Here is the training curve for the training process:</p>
-            <div class="image-gr">
+            <div class="grid-1">
         <div class="image-container">
             <img src="images5/class3.png" alt="Illustration of class3">
         </div>
         </div>
         <div class="clear-float"></div>
     <p>Now, I sample the class-conditioned UNet for 5 and 20 epochs Here is the result for 4 instances of each digit at 5 and 20 epochs:</p>
-    <div class="image-gri">
+    <div class="grid-2">
         <div class="image-container">
             <img src="images5/class1.png" alt="Illustration of class1">
         </div>

--- a/project6.html
+++ b/project6.html
@@ -17,7 +17,7 @@
     <div class="project-overview">
         <h2>Part 1: Fit a Neural Field to a 2D Image</h2>
             <p> In this section, I implement Neural Radiance Field in 2 dimensions. In 2 dimensions, we don't have the concept of radiance so essentially Neural Radiance Field in 2 dimensions reduces to Neural Field, in which we represent 2D by mapping (u,v) to (R,G,B) - converting the pixel coordinate to RGB values. For this, I created Multilayer Perceptron and Sinusoidal Positional Encoding with given architecture. For Multilayer Perceptron, I used 4 hidden layers(size 256) with RELU and a linear layer(size 3) with sigmoid. Also, I created a dataloader that randomly samples certain number of pixels from the image at each iteration. To determine the correct hyperparameters, I have explored different values for learning rate and max frequency L for the given image.  As the baseline, I used the hyperparameters layers=4, hidden dim=256, L=10, LR=1e-2. Firstly, I explored the effect of max frequency L. Here are my results for the baseline, L=20, LR=5: </p>
-                <div class="image-grid">
+                <div class="grid-3">
             <div class="image-container">
                 <img src="proj5images/baseline_psnrr.png" alt="Baseline PSNR Curve">
                 <p class="image-subtitle"> Baseline PSNR Curve</p>
@@ -46,7 +46,7 @@
         <div class="clear-float"></div>
         <p> From the images, it is clear that reducing the max frequency from 10 to 5 resulted in worse performance. Also, the increase from 10 to 20 did not improve the model's performance visibly, PSNR curves seemed to converge to similar value. Thus, I decided to use L=10. </p>
         <p> As another hyperparameter, I varying the learning rate. Here are my results for the  baseline, LR=0.02, L=0.005:</p>
-                <div class="image-grid">
+                <div class="grid-3">
             <div class="image-container">
                 <img src="proj5images/baseline_psnrr.png" alt="Baseline PSNR Curve">
                 <p class="image-subtitle"> Baseline PSNR Curve</p>
@@ -75,7 +75,7 @@
         <div class="clear-float"></div>
         <p> Training curves look pretty similar, but halving the learning rate caused a slight drop in performance. Also, for learning rate 2e-2, I think the final image has worse quality than the final image for the baseline.</p>
         <p>Here are my results for the given image, sampled at every 400 iterations. I trained the model for 2001 iterations. For this training, I used the following hyperparameters, layers=4, hidden dim=256, L=10, LR=1e-2:</p>
-        <div class="image-grid">
+        <div class="grid-3">
             <div class="image-container">
                 <img src="proj5images/baseline_psnrr.png" alt="Training PSNR Curve">
                 <p class="image-subtitle"> Training PSNR Curve</p>
@@ -107,7 +107,7 @@
                     </div>
         <div class="clear-float"></div>
         <p>I also ran my training loop for another image of my choosing, a crocodile. For this training, I used the following hyperparameters, layers=4, hidden dim=256, L=10, LR=5e-3:. Here are my results for the image, and my training curve: </p>    
-                <div class="image-grid">
+                <div class="grid-3">
                             <div class="image-container">
                 <img src="proj5images/images.jpeg" alt="Original Image">
                 <p class="image-subtitle"> Original Image</p>
@@ -149,7 +149,7 @@
         <p> In this part, I defined the required functions, transform(c2w, x_c), pixel_to_camera(c2w, x_c), pixel_to_ray(K, c2w, x_c). transform function takes in camera coordinates and obtains the corresponding world coordinates using c2w matrix. pixel_to_camera takes in pixel coordinates and obtains camera coordinates, using the intrinsic matrix K. pixel_to_ray takes in world coordinates, and by using the other functions, obtains rays with origin and normalized directions.</p>
         <h2>Part 2.3: Putting the Dataloading All Together</h2>
         <p>In this part, I put everything I did so far together to visualize the given tests:</p>
-                <div class="image-grid">
+                <div class="grid-3">
             <div class="image-container">
                 <img src="proj5images/sa1.png" alt="Cameras, 100 Rays, Samples">
                 <p class="image-subtitle"> Cameras, 100 Rays, Samples</p>
@@ -166,7 +166,7 @@
         <div class="clear-float"></div>
         <h2>Part 2.4: Neural Radiance Field</h2>
         <p>In this part, I implement the NeRF architecture. It is similar to MLP but there are some changes as we have samples in 3D, and want to predict density and color of the samples. One of the main changes are now the MLP is deeper because the task we are trying to implement is harder. Also, we are not only going to output color but also density for the inputs, which are 3D world coordinates and ray direction. For this, I will use the direction as the condition to output colors. Lastly, I inject the input to the middle of the MLP after getting it through PE I defined earlier to make model not forget about the input as the neural network got deeper. For this part, I used the given architecture:</p>
-                        <div class="image-gr">
+                        <div class="grid-1">
             <div class="image-container">
                 <img src="proj5images/mlp_nerf.png" alt="Illustration of mlp nerf">
             </div>
@@ -174,20 +174,20 @@
         <div class="clear-float"></div>
                 <h2>Part 2.5:  Volume Rendering</h2>
         <p> In order to obtain render colors, I used the given volume rendering equation, which combined the batches of samples from each ray:</p>
-                                <div class="image-gr">
+                                <div class="grid-1">
             <div class="image-container">
                 <img src="proj5images/volrend.png" alt="Illustration of volrend">
             </div>
          </div>
         <div class="clear-float"></div>
         <p>Here is the visualized training, predictions shown for each 100 iterations. I used the given hyperparameters, and trained the model for 1000 iterations. Also, I provide the PSNR curve on the validation set (every 10 iterations) and the training set.</p>
-                        <div class="image-gr">
+                        <div class="grid-1">
         <div class="image-container">
             <img src="proj5images/psnrn.png" alt="Illustration of psnrn">
         </div>
         </div>
         <div class="clear-float"></div>
-                        <div class="image-gi">
+                        <div class="grid-3">
                                     <div class="image-container">
             <img src="proj5images/validation0.png" alt="Illustration of validation0">
         </div>
@@ -224,7 +224,7 @@
         </div>
         <div class="clear-float"></div>
         <p>Combining everything together, here is a spherical rendering of lego using the provided camera extrinsics:</p>
-                <div class="image-gr">
+                <div class="grid-1">
         <div class="image-container">
             <img src="proj5images/leg.gif" alt="Illustration of leg">
         </div>
@@ -232,7 +232,7 @@
         <div class="clear-float"></div>
         <h2>B&W: Background Coloring</h2>
         <p>For bells and whistles, I implement the background color. The background color is added to the rendered scene by treating it as the color seen when a ray passes through all objects without being blocked:</p>
-        <div class="image-gr">
+        <div class="grid-1">
         <div class="image-container">
             <img src="proj5images/lego_backgroun.gif" alt="Illustration of lego backgroun">
         </div>

--- a/style.css
+++ b/style.css
@@ -26,12 +26,13 @@ h1 {
     margin-bottom: 20px;
 }
 
-.image-grid {
+.grid-3 {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 15px;
     margin-bottom: 20px;
 }
+
 
 .image-container {
     background-color: #fff;
@@ -71,14 +72,14 @@ h1 {
     margin-bottom: 20px;
 }
 
-.image-gri {
+.grid-2 {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: 15px;
     margin-bottom: 20px;
 }
 
-.image-gr {
+.grid-1 {
     display: grid;
     grid-template-columns: repeat(1, 1fr);
     gap: 15px;
@@ -87,42 +88,25 @@ h1 {
     align-items: center;
 }
 
-.image-g {
-    display: grid;
-    grid-template-columns: repeat(6, 1fr);
-    gap: 15px;
-    margin-bottom: 20px;
-}
-
-.image-gi {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 15px;
-    margin-bottom: 20px;
-}
-
-.image-grrid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 15px;
-    margin-bottom: 20px;
-}
-
-.image-grrid img {
-    width: 40%;
-    height: 40%;
-    object-fit: contain;
-}
-
-.image-griddd {
-    display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    gap: 15px;
-    margin-bottom: 20px;
-}
-
-.image-griddd, .image-grrid, .image-gi, .image-g {
+.grid-3 img,
+.grid-2 img,
+.grid-1 img {
     width: 100%;
+}
+
+@media (max-width: 768px) {
+    .grid-3 {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .grid-2 {
+        grid-template-columns: repeat(1, 1fr);
+    }
+}
+
+@media (max-width: 480px) {
+    .grid-3 {
+        grid-template-columns: repeat(1, 1fr);
+    }
 }
 
 .project-link {


### PR DESCRIPTION
## Summary
- replace custom grid classes with `.grid-1`, `.grid-2`, `.grid-3`
- update all HTML pages to use the new classes
- add responsive media queries for grids

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686e3b96907c83298a677445c5332283